### PR TITLE
Upgrade Waggle Dance version to 3.8.0 (was 3.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2021-01-14
+### Changed
+- Upgrade Waggle Dance version to `3.8.0`, was `3.6.0`.
+
 ## [1.5.0] - 2020-03-05
 ### Changed
 - Upgrade Waggle Dance version to `3.6.0`, was `3.3.2`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM amazonlinux:latest
 
 ENV JAVA_VERSION 1.8.0
-ENV WAGGLE_DANCE_VERSION 3.6.0
+ENV WAGGLE_DANCE_VERSION 3.8.0
 ENV WAGGLE_DANCE_HOME /opt/waggle-dance
 
 RUN yum -y update && \


### PR DESCRIPTION
## [1.6.0] - 2021-01-14
### Changed
- Upgrade Waggle Dance version to `3.8.0`, was `3.6.0`.