### PR TITLE
Feature/upgrade runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   apiary-docker-image:
     name: Apiary Docker Image Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code  
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   apiary-docker-image:
     name: Apiary Docker Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code  
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.9.4] - 2023-05-04
+## [1.9.4] - 2023-05-08
 ### Changed
 - Upgrade Waggle Dance version to `3.10.12` (was `3.10.11`) to upgrade `springboot` version.
 - Change `amazonlinux` tag to `2` (was `latest`) to keep the build consistent.
+- Upgrade github action runner from `ubuntu-18.04` to `ubuntu-22.04`.
 
 ## [1.9.3] - 2023-02-07
 ### Changed


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-waggledance-docker/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description
Upgrading the version of the runners because current ones are deprecated see https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/ 

### :link: Related Issues
