### PR TITLE
fix: update docker push action version to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Release Apiary Docker Image
-      uses: docker/build-push-action@v1.1.0
+      uses: docker/build-push-action@v6
       with:
         dockerfile: "Dockerfile"
         always_pull: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CODE-OF-CONDUCT.md for more details.
  https://github.com/ExpediaGroup/apiary-waggledance-docker/blob/master/CODE-OF-CONDUCT.md
-->

### :pencil: Description


### :link: Related Issues
